### PR TITLE
Fix errors with spaces in directories

### DIFF
--- a/src/_adr_add_link
+++ b/src/_adr_add_link
@@ -8,7 +8,7 @@ target=$("$adr_bin_dir/_adr_file" "${3:?TARGET}")
 
 target_title="$("$adr_bin_dir/_adr_title" "$target")"
 
-awk -v link_type="$link_type" -v target="$(basename $target)" -v target_title="$target_title" '
+awk -v link_type="$link_type" -v target="$(basename "$target")" -v target_title="$target_title" '
 	BEGIN {
 		in_status_section=0
 	}

--- a/src/_adr_add_link
+++ b/src/_adr_add_link
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname $0)"/adr-config)"
 
-source=$("$adr_bin_dir/_adr_file" "${1:?SOURCE}")
+source=$("$adr_bin_dir"/_adr_file "${1:?SOURCE}")
 link_type="${2:?LINK TYPE}"
 target=$("$adr_bin_dir/_adr_file" "${3:?TARGET}")
 
 target_title="$("$adr_bin_dir/_adr_title" "$target")"
 
 awk -v link_type="$link_type" -v target="$(basename $target)" -v target_title="$target_title" '
-	BEGIN { 
+	BEGIN {
 		in_status_section=0
 	}
 	/^##/ {
@@ -19,8 +19,8 @@ awk -v link_type="$link_type" -v target="$(basename $target)" -v target_title="$
 		}
 		in_status_section=0
 	}
-	/^## Status$/ { 
-		in_status_section=1 
+	/^## Status$/ {
+		in_status_section=1
 	}
 	{ print }
 ' "$source" > "$source.tmp"

--- a/src/_adr_autocomplete
+++ b/src/_adr_autocomplete
@@ -1,5 +1,5 @@
 #!/bin/bash
-eval "$("$(dirname $0)"/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 cmds=("$@")
 available_commands=$( "$adr_bin_dir"/_adr_commands | sort )

--- a/src/_adr_autocomplete
+++ b/src/_adr_autocomplete
@@ -1,8 +1,8 @@
 #!/bin/bash
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname $0)"/adr-config)"
 
 cmds=("$@")
-available_commands=$( $adr_bin_dir/_adr_commands | sort )
+available_commands=$( "$adr_bin_dir"/_adr_commands | sort )
 
 if (( ${#@} <= 2))
 then

--- a/src/_adr_commands
+++ b/src/_adr_commands
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname $0)"/adr-config)"
 
 for f in $(cd "$adr_bin_dir" && find . -name 'adr-*')
 do

--- a/src/_adr_dir
+++ b/src/_adr_dir
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname $0)"/adr-config)"
 
 reldir=.
 
@@ -10,16 +10,16 @@ function mkrel() {
 }
 
 function absdir() {
-	(cd $(dirname $1) && pwd -P)
+	(cd "$(dirname $1)" && pwd -P)
 }
 
-while [ $(absdir $reldir) != / ]
+while [ "$(absdir $reldir)" != / ]
 do
-	if [ -f $(mkrel .adr-dir) ]
+	if [ -f "$(mkrel .adr-dir)" ]
 	then
-	    mkrel $(cat $(mkrel .adr-dir))
+	    mkrel "$(cat "$(mkrel .adr-dir)")"
 		exit
-	elif [ -d $(mkrel doc/adr) ] 
+	elif [ -d "$(mkrel doc/adr)" ]
 	then
 		mkrel doc/adr
 		exit

--- a/src/_adr_file
+++ b/src/_adr_file
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname $0)"/adr-config)"
 
 "$adr_bin_dir/adr-list" | grep "$1" | head -1

--- a/src/_adr_generate_graph
+++ b/src/_adr_generate_graph
@@ -58,6 +58,7 @@ echo "digraph {"
 echo "  node [shape=plaintext];"
 
 echo "  subgraph {"
+IFS=$'\n'
 for f in $("$adr_bin_dir/adr-list")
 do
 	n=$(index "$f")

--- a/src/_adr_generate_graph
+++ b/src/_adr_generate_graph
@@ -1,25 +1,25 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 ## usage: adr generate graph [-p LINK_PREFIX] [-e LINK-EXTENSION]
 ##
 ## Generates a visualisation of the links between decision records in
-## Graphviz format.  This can be piped into the graphviz tools to 
+## Graphviz format.  This can be piped into the graphviz tools to
 ## generate a an image file.
-## 
+##
 ## Each node in the graph represents a decision record and is linked to
-## the decision record document.  
+## the decision record document.
 ##
 ## Options:
 ##
-## -e LINK-EXTENSION 
-##         the file extension of the documents to which generated links refer. 
+## -e LINK-EXTENSION
+##         the file extension of the documents to which generated links refer.
 ##         Defaults to `.html`.
-## 
-## -p LINK_PREFIX 
+##
+## -p LINK_PREFIX
 ##         prefix each decision file link with LINK_PREFIX.
-## 
+##
 ## E.g. to generate a graph visualisation of decision records in SVG format:
 ##
 ##     adr generate graph | dot -Tsvg > graph.svg
@@ -35,7 +35,7 @@ link_extension=.html
 while getopts e:p: arg
 do
     case "$arg" in
-        e) 
+        e)
 			link_extension="$OPTARG"
           	;;
 		p)
@@ -61,12 +61,12 @@ echo "  subgraph {"
 for f in $("$adr_bin_dir/adr-list")
 do
 	n=$(index "$f")
-	title=$("$adr_bin_dir/_adr_title" $f)
-	
-	echo "    _$n [label=\"$title\"; URL=\"${link_prefix}$(basename $f .md)${link_extension}\"];"
-	if [ $n -gt 1 ]
+	title=$("$adr_bin_dir/_adr_title" "$f")
+
+	echo "    _$n [label=\"$title\"; URL=\"${link_prefix}$(basename "$f" .md)${link_extension}\"];"
+	if [ "$n" -gt 1 ]
 	then
-		echo "    _$(($n - 1)) -> _$n [style=\"dotted\", weight=1];"
+		echo "    _$(("$n" - 1)) -> _$n [style=\"dotted\", weight=1];"
 	fi
 done
 echo "  }"

--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$("$(dirname $0)"/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 ## usage: adr generate toc [-i INTRO] [-o OUTRO] [-p LINK_PREFIX]
 ##
@@ -56,8 +56,8 @@ fi
 
 for f in $("$adr_bin_dir/adr-list")
 do
-    title=$("$adr_bin_dir/_adr_title" $f)
-    link=${link_prefix}$(basename $f)
+    title=$("$adr_bin_dir/_adr_title" "$f")
+    link=${link_prefix}$(basename "$f")
 
     echo "* [$title]($link)"
 done

--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -54,6 +54,7 @@ then
     echo
 fi
 
+IFS=$'\n'
 for f in $("$adr_bin_dir/adr-list")
 do
     title=$("$adr_bin_dir/_adr_title" "$f")

--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname $0)"/adr-config)"
 
 ## usage: adr generate toc [-i INTRO] [-o OUTRO] [-p LINK_PREFIX]
 ##
@@ -10,12 +10,12 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ## -i INTRO  precede the table of contents with the given INTRO text.
 ## -o OUTRO  follow the table of contents with the given OUTRO text.
-## -p LINK_PREFIX   
+## -p LINK_PREFIX
 ##           prefix each decision file link with LINK_PREFIX.
 ##
 ## Both INTRO and OUTRO must be in Markdown format.
 
-args=$(getopt i:o:p: $*)
+args=$(getopt i:o:p: "$@")
 set -- $args
 
 link_prefix=
@@ -48,7 +48,7 @@ cat <<EOF
 
 EOF
 
-if [ ! -z $intro ]
+if [ -n "$intro" ]
 then
     cat "$intro"
     echo

--- a/src/_adr_help
+++ b/src/_adr_help
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 cmds=("$@")
 
@@ -27,10 +27,10 @@ else
 	else
 		grep -E '^##' "$cmdexe" | cut -c 4-
 	fi
-	
+
 	# Assumes only two levels of command / subcommand.
 	subcmds=( $(compgen -G "$adr_bin_dir/_adr_$1_"'*') )
-	
+
 	if (( ${#subcmds} > 0 ))
 	then
 		echo

--- a/src/_adr_help_new
+++ b/src/_adr_help_new
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 cat <<ENDHELP
 usage: adr new [-s SUPERCEDED] [-l TARGET:LINK:REVERSE-LINK] TITLE_TEXT...
@@ -30,14 +30,14 @@ Options:
                 it has been superceded by the new ADR.
 
 -l TARGET:LINK:REVERSE-LINK
-                Links the new ADR to a previous ADR.  
-                TARGET is a reference (number or partial filename) of a 
-                previous decision. 
+                Links the new ADR to a previous ADR.
+                TARGET is a reference (number or partial filename) of a
+                previous decision.
                 LINK is the description of the link created in the new ADR.
                 REVERSE-LINK is the description of the link created in the
                 existing ADR that will refer to the new ADR.
 
-Multiple -s and -l options can be given, so that the new ADR can supercede 
+Multiple -s and -l options can be given, so that the new ADR can supercede
 or link to multiple existing ADRs.
 
 E.g. to create a new ADR with the title "Use MySQL Database":

--- a/src/_adr_links
+++ b/src/_adr_links
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 "$adr_bin_dir/_adr_status" "$1" | sed -n -E 's/^(.+) \[.*\]\(0*([1-9][0-9]*).*\)/\2=\1/p'

--- a/src/_adr_remove_status
+++ b/src/_adr_remove_status
@@ -1,27 +1,27 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 current_status=${1:?FROM}
 file=$("$adr_bin_dir/_adr_file" "${2:?FILE}")
 
 awk -v current_status="$current_status" '
-	BEGIN { 
-		in_status_section=0 
+	BEGIN {
+		in_status_section=0
 	}
-	/^##/ { 
-		in_status_section=0 
+	/^##/ {
+		in_status_section=0
 	}
-	/^## Status$/ { 
-		in_status_section=1 
+	/^## Status$/ {
+		in_status_section=1
 	}
 	in_status_section && /^\s*$/ {
 		if (!after_blank) print
 		after_blank=1
 		next
 	}
-	in_status_section && $0 == current_status { 
-		next 
+	in_status_section && $0 == current_status {
+		next
 	}
 	in_status_section && ! /^\s*$/ {
 		after_blank=0

--- a/src/_adr_status
+++ b/src/_adr_status
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 awk '
-/^## Status/,/^#/ && !/^## Status/ { 
+/^## Status/,/^#/ && !/^## Status/ {
 	if (!/^(#|\s*$)/) print
 }
 ' "$("$adr_bin_dir/_adr_file" "$1")"

--- a/src/_adr_title
+++ b/src/_adr_title
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
-head -1 $("$adr_bin_dir/_adr_file" "$1") | cut -c 3-
+head -1 "$("$adr_bin_dir/_adr_file" "$1")" | cut -c 3-

--- a/src/adr
+++ b/src/adr
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 cmd=$adr_bin_dir/adr-$1
 
-if [ -x $cmd ]
+if [ -x "$cmd" ]
 then
     $cmd "${@:2}"
 else
-    $adr_bin_dir/adr-help
+    "$adr_bin_dir"/adr-help
     exit 1
 fi

--- a/src/adr-config
+++ b/src/adr-config
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Config for when running from the source directory.
 
-basedir=$(cd -L $(dirname $0) >/dev/null 2>&1 && pwd -L)
+basedir=$(cd -L "$(dirname "$0")" >/dev/null 2>&1 && pwd -L)
 
 echo 'adr_bin_dir="'"${basedir}"'"'
 echo 'adr_template_dir="'"${basedir}"'"'

--- a/src/adr-generate
+++ b/src/adr-generate
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 ## usage: adr generate [REPORT [OPTION ...]]
 ##
 ## Generates summary documentation about the architecture decision records
-## that is typically fed into the tool chain for publishing a project's 
+## that is typically fed into the tool chain for publishing a project's
 ## documentatation.
 ##
 ## To list the report types that can be generated, run:
@@ -16,7 +16,7 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ##     adr help generate <report-type>
 ##
-## For example, the following command will run the "toc" (table of contents) 
+## For example, the following command will run the "toc" (table of contents)
 ## generator:
 ##
 ##     adr generate toc
@@ -27,7 +27,7 @@ eval "$($(dirname $0)/adr-config)"
 
 cmd=$1
 
-if [ -z $cmd ]
+if [ -z "$cmd" ]
 then
     (cd "$adr_bin_dir" && find . -name '_adr_generate_*') | cut -c 17-
 else

--- a/src/adr-help
+++ b/src/adr-help
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 ## usage: adr help [COMMAND [SUBCOMMAND...]]
 ##
-## If COMMAND and any SUBCOMMANDs are given, displays help for that command. 
+## If COMMAND and any SUBCOMMANDs are given, displays help for that command.
 ## Otherwise lists the available commands.
 ##
 ## Uses the environment variables ADR_PAGER or PAGER (in that order) to

--- a/src/adr-init
+++ b/src/adr-init
@@ -1,18 +1,18 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 ## usage: adr init [DIRECTORY]
-## 
+##
 ## Initialises the directory of architecture decision records:
-## 
+##
 ##  * creates a subdirectory of the current working directory
 ##  * creates the first ADR in that subdirectory, recording the decision to
 ##    record architectural decisions with ADRs.
 ##
 ## If the DIRECTORY is not given, the ADRs are stored in the directory `doc/adr`.
 
-if [ ! -z $1 ]
+if [ -n "$1" ]
 then
     mkdir -p "$1"
     echo "$1" > .adr-dir

--- a/src/adr-link
+++ b/src/adr-link
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 ## usage: adr link SOURCE LINK TARGET REVERSE-LINK
 ##

--- a/src/adr-list
+++ b/src/adr-list
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 ## usage: adr list
 ##
@@ -8,9 +8,9 @@ eval "$($(dirname $0)/adr-config)"
 
 adr_dir=$("$adr_bin_dir/_adr_dir")
 
-if [ -d $adr_dir ]
+if [ -d "$adr_dir" ]
 then
-   find $adr_dir | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort
+   find "$adr_dir" | grep -E "^$adr_dir/[0-9]+-[^/]*\\.md" | sort
 else
     echo "The $adr_dir directory does not exist"
     exit 1

--- a/src/adr-new
+++ b/src/adr-new
@@ -105,7 +105,7 @@ dstfile="$dstdir"/$newid-$slug.md
 date=${ADR_DATE:-$(date +%Y-%m-%d)}
 
 mkdir -p "$dstdir"
-cat $template | sed \
+cat "$template" | sed \
     -e "s|NUMBER|$newnum|" \
     -e "s|TITLE|$title|" \
     -e "s|DATE|$date|" \

--- a/src/adr-new
+++ b/src/adr-new
@@ -91,9 +91,9 @@ then
     exit 1
 fi
 
-if [ -d $dstdir ]
+if [ -d "$dstdir" ]
 then
-    maxid=$(ls $dstdir | grep -Eo '^[0-9]+' | sed -e 's/^0*//' | sort -rn | head -1)
+    maxid=$(ls "$dstdir" | grep -Eo '^[0-9]+' | sed -e 's/^0*//' | sort -rn | head -1)
     newnum=$(($maxid + 1))
 else
     newnum=1
@@ -101,16 +101,16 @@ fi
 
 newid=$(printf "%04d" $newnum)
 slug=$(echo -n $title | tr -Ccs "[:alnum:]" - | tr "[:upper:]" "[:lower:]" | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
-dstfile=$dstdir/$newid-$slug.md
+dstfile="$dstdir"/$newid-$slug.md
 date=${ADR_DATE:-$(date +%Y-%m-%d)}
 
-mkdir -p $dstdir
+mkdir -p "$dstdir"
 cat $template | sed \
     -e "s|NUMBER|$newnum|" \
     -e "s|TITLE|$title|" \
     -e "s|DATE|$date|" \
     -e "s|STATUS|Accepted|" \
-    > $dstfile
+    > "$dstfile"
 
 for target in "${superceded[@]}"
 do

--- a/src/adr-new
+++ b/src/adr-new
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 ## usage: adr new [-s SUPERCEDED] [-l TARGET:LINK:REVERSE-LINK] TITLE_TEXT...
 ##
@@ -26,14 +26,14 @@ eval "$($(dirname $0)/adr-config)"
 ##                 it has been superceded by the new ADR.
 ##
 ## -l TARGET:LINK:REVERSE-LINK
-##                 Links the new ADR to a previous ADR.  
-##                 TARGET is a reference (number or partial filename) of a 
-##                 previous decision. 
+##                 Links the new ADR to a previous ADR.
+##                 TARGET is a reference (number or partial filename) of a
+##                 previous decision.
 ##                 LINK is the description of the link created in the new ADR.
 ##                 REVERSE-LINK is the description of the link created in the
 ##                 existing ADR that will refer to the new ADR.
 ##
-## Multiple -s and -l options can be given, so that the new ADR can supercede 
+## Multiple -s and -l options can be given, so that the new ADR can supercede
 ## or link to multiple existing ADRs.
 ##
 ## E.g. to create a new ADR with the title "Use MySQL Database":
@@ -100,7 +100,7 @@ else
 fi
 
 newid=$(printf "%04d" $newnum)
-slug=$(echo -n $title | tr -Ccs [:alnum:] - | tr [:upper:] [:lower:] | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
+slug=$(echo -n $title | tr -Ccs "[:alnum:]" - | tr "[:upper:]" "[:lower:]" | sed -e 's/[^[:alnum:]]*$//' -e 's/^[^[:alnum:]]*//')
 dstfile=$dstdir/$newid-$slug.md
 date=${ADR_DATE:-$(date +%Y-%m-%d)}
 
@@ -124,7 +124,7 @@ do
 	target="$(echo $l | cut -d : -f 1)"
 	forward_link="$(echo $l | cut -d : -f 2)"
 	reverse_link="$(echo $l | cut -d : -f 3)"
-	
+
 	"$adr_bin_dir/_adr_add_link" "$dstfile" "$forward_link" "$target"
 	"$adr_bin_dir/_adr_add_link" "$target" "$reverse_link" "$dstfile"
 done

--- a/src/adr-upgrade-repository
+++ b/src/adr-upgrade-repository
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-eval "$($(dirname $0)/adr-config)"
+eval "$("$(dirname "$0")"/adr-config)"
 
 ## usage: adr upgrade-repository
 ##

--- a/tests/init-with-spaces-in-directory.expected
+++ b/tests/init-with-spaces-in-directory.expected
@@ -1,0 +1,2 @@
+adr init "test doc/adr"
+test doc/adr/0001-record-architecture-decisions.md

--- a/tests/init-with-spaces-in-directory.sh
+++ b/tests/init-with-spaces-in-directory.sh
@@ -1,0 +1,1 @@
+adr init "test doc/adr"


### PR DESCRIPTION
This PR fixes errors when there are spaces in directories. Fixing this allows us to use this tool with Readme.com's git sync.