### PR TITLE
Add reading the ADR title from Markdown frontmatter

### DIFF
--- a/src/_adr_title
+++ b/src/_adr_title
@@ -2,4 +2,11 @@
 set -e
 eval "$("$(dirname "$0")"/adr-config)"
 
-head -1 "$("$adr_bin_dir/_adr_file" "$1")" | cut -c 3-
+title="$(head -2 "$("$adr_bin_dir/_adr_file" "$1")" | grep -E '^title: (.*)' | cut -c 8-)"
+
+if [ ! -n "$title" ]
+then
+    title="$(head -2 "$("$adr_bin_dir/_adr_file" "$1")" | grep -E '^# (.*)' | cut -c 3-)"
+fi
+
+echo $title


### PR DESCRIPTION
The PR adds reading the ADR title from Markdown frontmatter. This allows us to use this tool better with Readme.com's git sync.